### PR TITLE
Fix handling of <br> tags in input

### DIFF
--- a/lib/htmltoooxml/xslt/base.xslt
+++ b/lib/htmltoooxml/xslt/base.xslt
@@ -51,25 +51,19 @@
     </a:p>
   </xsl:template>
 
-
   <xsl:template match="br[not(ancestor::p) and not(ancestor::div) and not(ancestor::td|ancestor::li) or
                           (preceding-sibling::div or following-sibling::div or preceding-sibling::p or following-sibling::p)]">
-    <a:p>
-      <a:r></a:r>
-    </a:p>
+    <a:p><a:endParaRPr/></a:p>
   </xsl:template>
 
   <xsl:template match="br[(ancestor::li or ancestor::td) and
                           (preceding-sibling::div or following-sibling::div or preceding-sibling::p or following-sibling::p)]">
-    <a:r>
-      <a:br />
-    </a:r>
+    <xsl:apply-templates />
+    <a:p><a:endParaRPr/></a:p>
   </xsl:template>
 
   <xsl:template match="br">
-    <a:r>
-      <a:br />
-    </a:r>
+    <a:p><a:endParaRPr/></a:p>
   </xsl:template>
 
   <xsl:template match="pre">
@@ -259,9 +253,7 @@
 
   <xsl:template match="div[contains(concat(' ', @class, ' '), ' -page-break ')]">
     <a:p>
-      <a:r>
-        <a:br a:type="page" />
-      </a:r>
+      <a:endParaRPr/>
     </a:p>
     <xsl:apply-templates />
   </xsl:template>

--- a/spec/xslt_simple_text_style_spec.rb
+++ b/spec/xslt_simple_text_style_spec.rb
@@ -27,6 +27,11 @@ describe "XSLT" do
     compare_resulting_ooxml_with_expected(html, "<a:p> <a:r> <a:t>Hello</a:t> </a:r> </a:p>")
   end
 
+  it "transforms a p with a br into a pptx block element with a break." do
+    html = '<html><head></head><body><p>Hello <br> Bob</p></body></html>'
+    compare_resulting_ooxml_with_expected(html, "<a:p> <a:r> <a:t>Hello </a:t> </a:r> </a:p><a:p><a:endParaRPr lang=\"en-US\" dirty=\"0\"/></a:p><a:p><a:r><a:t> Bob</a:t></a:r> </a:p>")
+  end
+
   it "transforms a b into pptx b" do
     html = '<html><head></head><body><p><b>Hello</b></p></body></html>'
     compare_resulting_ooxml_with_expected(html, "<a:p> <a:r> <a:rPr dirty=\"0\" b=\"1\"/> <a:t>Hello</a:t> </a:r> </a:p>")


### PR DESCRIPTION
 - should use the <a:p><a:endParaRPr/></a:p> to replace a br but needs to close the <a:p> tag from the previous text element and then reopon a <a:p> tag post insertion so it looks something like:

 <a:p><a:r><a:t>Hello</a:t></a:r></a:p><a:p><a:endParaRPr/></a:p><a:p><a:r><a:t>Bob</a:t></a:r></a:p>