### PR TITLE
Jb col7296 preserve whitespace in formated sentence

### DIFF
--- a/lib/htmltoooxml/version.rb
+++ b/lib/htmltoooxml/version.rb
@@ -1,3 +1,3 @@
 module Htmltoooxml
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end

--- a/lib/htmltoooxml/xslt/inline_elements.xslt
+++ b/lib/htmltoooxml/xslt/inline_elements.xslt
@@ -1,7 +1,7 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:output encoding="utf-8" omit-xml-declaration="yes" indent="yes" />
 
-  <xsl:strip-space elements="*"/>
+  <xsl:preserve-space elements="p div span b i u s sub sup a"/>
 
   <xsl:template match="node()|@*">
     <xsl:copy>

--- a/spec/xslt_simple_text_style_spec.rb
+++ b/spec/xslt_simple_text_style_spec.rb
@@ -37,6 +37,11 @@ describe "XSLT" do
     compare_resulting_ooxml_with_expected(html, "<a:p> <a:r> <a:rPr dirty=\"0\" b=\"1\"/> <a:t>Hello</a:t> </a:r> </a:p>")
   end
 
+  it "preserves whitespace between inline elements" do
+    html = '<html><head></head><body><p><b>foo</b> <i>bar</i></p></body></html>'
+    compare_resulting_ooxml_with_expected(html, "<a:p> <a:r> <a:rPr dirty=\"0\" b=\"1\"/> <a:t>foo</a:t> </a:r> <a:r> <a:rPr dirty=\"0\" i=\"1\"/> <a:t>bar</a:t> </a:r> </a:p>")
+  end
+
   it "transforms a href into pptx link" do
     html = '<html><head></head><body><p><a href="http://www.somewhere.com">Hello</a></p></body></html>'
     compare_resulting_ooxml_with_expected(html, "<a:p> <a:r> <a:rPr> <a:hlinkClick r:id=\"rId100\"/></a:rPr> <a:t>Hello</a:t> </a:r> </a:p>")

--- a/spec/xslt_simple_text_style_spec.rb
+++ b/spec/xslt_simple_text_style_spec.rb
@@ -29,7 +29,7 @@ describe "XSLT" do
 
   it "transforms a p with a br into a pptx block element with a break." do
     html = '<html><head></head><body><p>Hello <br> Bob</p></body></html>'
-    compare_resulting_ooxml_with_expected(html, "<a:p> <a:r> <a:t>Hello </a:t> </a:r> </a:p><a:p><a:endParaRPr lang=\"en-US\" dirty=\"0\"/></a:p><a:p><a:r><a:t> Bob</a:t></a:r> </a:p>")
+    compare_resulting_ooxml_with_expected(html, "<a:p><a:r><a:t>Hello </a:t></a:r><a:p><a:endParaRPr/></a:p><a:r><a:t> Bob</a:t></a:r></a:p>")
   end
 
   it "transforms a b into pptx b" do


### PR DESCRIPTION
 - define preserve-space for formatting elements we want
 - update tests
 - The p>br test needed updating based on the previous merge of the br fix https://github.com/stylefoundry/html_to_ooxml/commit/205bc810335ef0824808b05d7020a9a0e59180d5